### PR TITLE
Add minimal-versions check to workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,3 +45,12 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Run clippy
         run: cargo clippy --all --all-targets -- -D warnings
+  min_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+      - name: Check the minimum possible crate versions
+        run: cargo +nightly build -Zdirect-minimal-versions

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,4 +53,4 @@ jobs:
         with:
           toolchain: nightly
       - name: Check the minimum possible crate versions
-        run: cargo +nightly build -Zdirect-minimal-versions
+        run: rm Cargo.lock && cargo +nightly build -Zdirect-minimal-versions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,9 +441,9 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "rustix"
-version = "0.37.17"
+version = "0.37.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc809f704c03a812ac71f22456c857be34185cac691a4316f27ab0f633bb9009"
+checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
 dependencies = [
  "bitflags",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ rust-version = "1.64"
 
 [workspace.dependencies]
 diff = { version = "0.1.12", default_features = false }
-regex = { version = "1.8", default_features = false, features = ["std"] }
+regex = { version = "1.3", default_features = false, features = ["std"] }
 regex-syntax = { version = "0.7", default_features = false }

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -26,7 +26,7 @@ ena = { version = "0.14", default_features = false }
 is-terminal = "0.4.2"
 itertools = { version = "0.10", default_features = false, features = ["use_std"] }
 petgraph = { version = "0.6", default_features = false }
-regex = { workspace = true }
+regex = { workspace = true, features = ["std"] }
 regex-syntax = { workspace = true }
 string_cache = { version = "0.8", default_features = false }
 term = { version = "0.7", default_features = false }


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->